### PR TITLE
Fixed bug that would prevent an egress attempt as HTTPS while providing port

### DIFF
--- a/EgressAssess.ps1
+++ b/EgressAssess.ps1
@@ -1326,7 +1326,7 @@ function Invoke-EgressAssess
                     }
                     else
                     {
-                        "https://" + $IP + ":" + $Port + "/post_data.php"
+                        $Url = "https://" + $IP + ":" + $Port + "/post_data.php"
                     }
                     
                 }


### PR DESCRIPTION
You forgot a "$Url = " before a string assignment and for some reason, that causes the script to completely silently fail.  Took me a while to figure out why