### PR TITLE
Fixed HTTP(S) issues for Linux server and client

### DIFF
--- a/Egress-Assess.py
+++ b/Egress-Assess.py
@@ -88,6 +88,10 @@ if __name__ == "__main__":
                     # protocol requested by the user
                     for proto_name, proto_module in the_conductor.client_protocols.items():
                         if proto_module.protocol == cli_parsed.client.lower():
+                            # If HTTP or HTTPS protocols, 
+                            # encode generated data to utf-8 for POST request
+                            if cli_parsed.client == "http" or cli_parsed.client == "https":
+                                generated_data = str.encode(generated_data)
                             proto_module.transmit(generated_data)
                             sys.exit()
 
@@ -97,7 +101,6 @@ if __name__ == "__main__":
 
             for proto_name, proto_module in the_conductor.client_protocols.items():
                 if proto_module.protocol == cli_parsed.client.lower():
-                    proto_module.transmit(file_data)
                     sys.exit()
 
         print("[*] Error: You either didn't provide a valid datatype or client protocol to use.")

--- a/protocols/clients/https_client.py
+++ b/protocols/clients/https_client.py
@@ -34,7 +34,7 @@ class Client:
         # noinspection PyProtectedMember
         ssl._create_default_https_context = ssl._create_unverified_context
         if not self.file_transfer:
-            url = 'https://' + self.remote_server + ':' + str(self.port) + '/post_file.php'
+            url = 'https://' + self.remote_server + ':' + str(self.port) + '/post_data.php'
 
             # Post the data to the web server at the specified URL
             try:

--- a/protocols/servers/https_server.py
+++ b/protocols/servers/https_server.py
@@ -30,12 +30,13 @@ class Server:
 
     def serve_on_port(self):
         try:
+            # Reference server.pem file created per README instructions
             cert_path = helpers.ea_path() +\
-                '/protocols/servers/serverlibs/web/server.pem'
+                '/server.pem'
             server = threaded_http.ThreadingHTTPServer(
                 ('0.0.0.0', self.port), base_handler.GetHandler)
             server.socket = ssl.wrap_socket(
-                server.socket, certfile=cert_path, server_side=True)
+                server.socket, keyfile=None, certfile=cert_path, server_side=True)
             server.serve_forever()
         except socket.error:
             print(f'[*] Error: Port {self.port} is currently in use.')


### PR DESCRIPTION
Fixed three issues that prevented HTTP and HTTPS transfers for the Linux server and client:
1. Error for not properly encoded data for POST request
2. Improper reference of pem file location for HTTPS request
3. HTTPS calls not properly mapped to post_data.php endpoint