### PR TITLE
transmit() was not called when an input file is specified

### DIFF
--- a/Egress-Assess.py
+++ b/Egress-Assess.py
@@ -101,6 +101,7 @@ if __name__ == "__main__":
 
             for proto_name, proto_module in the_conductor.client_protocols.items():
                 if proto_module.protocol == cli_parsed.client.lower():
+                    proto_module.transmit(file_data)
                     sys.exit()
 
         print("[*] Error: You either didn't provide a valid datatype or client protocol to use.")

--- a/protocols/clients/icmp_client.py
+++ b/protocols/clients/icmp_client.py
@@ -54,10 +54,10 @@ class Client:
 
         while byte_reader < len(data_to_transmit):
             if not self.file_transfer:
-                encoded_data = base64.b64encode(data_to_transmit[byte_reader:byte_reader + self.length])
+                encoded_data = base64.b64encode(data_to_transmit[byte_reader:byte_reader + self.length].encode())
             else:
-                encoded_data = base64.b64encode(self.file_transfer +
-                                                ".:::-989-:::." + data_to_transmit[byte_reader:byte_reader + self.length])
+                encoded_data = base64.b64encode((self.file_transfer +
+                                                ".:::-989-:::." + (data_to_transmit[byte_reader:byte_reader + self.length]).decode('utf-8')).encode())
 
             print('[*] Packet Number/Total Packets:        ' + str(packet_number) + "/" + str(total_packets))
 


### PR DESCRIPTION
When running something like 
`sudo python3 Egress-Assess.py --client icmp --ip [IP] --file sample-text-file.txt`
The code would just exit:
<img width="901" alt="Screen Shot 2022-10-12 at 11 19 56 AM" src="https://user-images.githubusercontent.com/9265217/195408062-8805307b-15cc-41ea-b46a-f3bb62afb53f.png">

When I dived deeper, it appears that transmit() was never called in the python script when an input file is specified. I added it back.
I also added some string to bytes encoding/decoding to fix errors python3 had in icmp_client.py. ICMP exfil now works with these fixes. 
